### PR TITLE
Fix bevy_polyline, pinning to the last compatible upstream Bevy revision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ path = "examples/nbody.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy.git", branch = "main" }
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev="de8edd3165c379e05aabb38359b3f4b97f46540a" }
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bevy_polyline"
 version = "0.1.0"
 edition = "2018"
+resolver = "2"
 
 [[example]]
 name = "linestrip"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ bevy = { git = "https://github.com/bevyengine/bevy.git", branch = "main" }
 [dev-dependencies]
 lazy_static = "1.4.0"
 rand = "0.8.3"
-ringbuffer = "0.7.1"
+ringbuffer = "0.8"
 
 [patch.crates-io]
 # bevy = { path = "../bevy" }

--- a/examples/linestrip.rs
+++ b/examples/linestrip.rs
@@ -2,7 +2,7 @@ use bevy::{pbr::PointLightBundle, prelude::*};
 use bevy_polyline::{Polyline, PolylineBundle, PolylineMaterial, PolylinePlugin};
 
 fn main() {
-    let mut app = App::build();
+    let mut app = App::new();
 
     app.insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
@@ -69,7 +69,8 @@ fn setup(
         .insert(Rotates);
 }
 
-/// this component indicates what entities should rotate
+/// This component indicates what entities should rotate
+#[derive(Component)]
 struct Rotates;
 
 fn rotator_system(time: Res<Time>, mut query: Query<&mut Transform, With<Rotates>>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ use bevy::{
     window::{WindowResized, Windows},
 };
 use bevy::{
-    prelude::{Bundle, CoreStage, Plugin, Visible},
+    prelude::{Bundle, Component, CoreStage, Plugin, Visible},
     render::shader,
 };
 
@@ -204,13 +204,13 @@ pub fn polyline_resource_provider_system(
     });
 }
 
-#[derive(Debug, Default, Reflect)]
+#[derive(Component, Debug, Default, Reflect)]
 #[reflect(Component)]
 pub struct Polyline {
     pub vertices: Vec<Vec3>,
 }
 
-#[derive(Reflect, RenderResources, ShaderDefs, TypeUuid)]
+#[derive(Component, Reflect, RenderResources, ShaderDefs, TypeUuid)]
 #[reflect(Component)]
 #[uuid = "0be0c53f-05c9-40d4-ac1d-b56e072e33f8"]
 pub struct PolylineMaterial {


### PR DESCRIPTION
Unfortunately, the commit after this pinned one is much harder to get working: the examples were all deleted!