### PR TITLE
Use mainline Bevy.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ authors = [
 
 [dependencies]
 bitflags = "1.3"
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
+bevy = { version = "0.6", default-features = false, features = [
     "render",
 ] }
 
@@ -30,7 +30,7 @@ version = "0.8.0"
 lazy_static = "1.4.0"
 rand = "0.8.4"
 ringbuffer = "0.8.2"
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
+bevy = { version = "0.6", default-features = false, features = [
     "bevy_winit",
     "x11",
 ] }


### PR DESCRIPTION
Using the crate-published version works! Also, this is trivial so feel free to just ignore it and make the change yourself.