### PR TITLE
Add depth_bias field to PolylineMaterial

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "bevy_polyline"
-version = "0.1.1"
+version = "0.3.0"
 description = "Polyline Rendering for Bevy"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/ForesightMiningSoftwareCorporation/bevy_polyline"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Usage of Bevy Polyline is quite simple. First add it to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bevy_polyline = "0.2"
+bevy_polyline = "0.3"
 ```
 
 You add it as a plugin to your app:

--- a/examples/depth_bias.rs
+++ b/examples/depth_bias.rs
@@ -1,0 +1,79 @@
+use std::f32::consts::TAU;
+use std::f64::consts::TAU as TAU64;
+
+use bevy::prelude::*;
+use bevy_polyline::prelude::*;
+
+fn main() {
+    App::new()
+        .insert_resource(ClearColor(Color::BLACK))
+        .insert_resource(Msaa { samples: 4 })
+        .add_plugins(DefaultPlugins)
+        .add_plugin(PolylinePlugin)
+        .add_system(rotate_plane)
+        .add_startup_system(setup)
+        .run();
+}
+
+#[derive(Component)]
+struct Rotating(f64);
+
+fn rotate_plane(time: Res<Time>, mut animated: Query<(&mut Transform, &Rotating)>) {
+    let time = time.seconds_since_startup();
+    for (mut trans, Rotating(period)) in animated.iter_mut() {
+        let angle = time % period / period * TAU64;
+        let rot = Quat::from_rotation_y(angle as f32);
+        trans.rotation = Quat::from_rotation_y(TAU / 4.1) * rot;
+    }
+}
+fn setup(
+    mut cmds: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut pbr_materials: ResMut<Assets<StandardMaterial>>,
+    mut polylines: ResMut<Assets<Polyline>>,
+    mut materials: ResMut<Assets<PolylineMaterial>>,
+) {
+    cmds.spawn_bundle(PerspectiveCameraBundle::new_3d())
+        .insert(Transform::from_xyz(100.0, 0.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y));
+    cmds.spawn_bundle(PbrBundle {
+        mesh: meshes.add(shape::Box::new(0.01, 100.0, 10000.0).into()),
+        material: pbr_materials.add(Color::WHITE.into()),
+        ..default()
+    })
+    .insert(Rotating(30.0));
+    let top = Vec3::Y * 100.0;
+    let bottom = Vec3::Y * -100.0;
+    // Show the middle point as a vertical red bar.
+    cmds.spawn_bundle(PolylineBundle {
+        polyline: polylines.add(Polyline {
+            vertices: vec![top, bottom],
+        }),
+        material: materials.add(PolylineMaterial {
+            width: 5.0,
+            color: Color::RED,
+            depth_bias: -1.0,
+            perspective: false,
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+    // Evaluate how "deep" the depth_bias makes the line change
+    for i in 0..100 {
+        let bias = (i as f32) / 50.0 - 1.0;
+        let left = Vec3::new(0.0, bias * 35.0, -500.0);
+        let right = Vec3::new(0.0, bias * 35.0, 500.0);
+        cmds.spawn_bundle(PolylineBundle {
+            polyline: polylines.add(Polyline {
+                vertices: vec![left, right],
+            }),
+            material: materials.add(PolylineMaterial {
+                width: 1.0,
+                color: Color::hsl((bias + 1.0) / 2.0 * 270.0, 1.0, 0.5),
+                depth_bias: bias,
+                perspective: false,
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+    }
+}

--- a/examples/depth_bias.rs
+++ b/examples/depth_bias.rs
@@ -4,12 +4,27 @@ use std::f64::consts::TAU as TAU64;
 use bevy::prelude::*;
 use bevy_polyline::prelude::*;
 
+// This example demonstrates how to use the `depth_bias` field on `PolylineMaterial`
+//
+// It should display on screen:
+// * A rotating plane centered on the screen that eventually intersects with the camera.
+// * A vertical red line that is drawn in front of everything.
+// * 100 horizontal lines, going from the top to the bottom of the screen going through
+//   all the colors of the rainbow.
+//
+// In addition, you can use the UP and DOWN arrow keys to move forward and backward the
+// camera.
+//
+// Each horizontal line has a different depth_bias, going from 1.0 at the top to -1.0 at
+// the bottom (the middle line is 0.0) In combination with the rotating plane, it should
+// demonstrate how different depth_bias values interact with geometry.
 fn main() {
     App::new()
         .insert_resource(ClearColor(Color::BLACK))
         .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
         .add_plugin(PolylinePlugin)
+        .add_system(move_camera)
         .add_system(rotate_plane)
         .add_startup_system(setup)
         .run();
@@ -24,6 +39,19 @@ fn rotate_plane(time: Res<Time>, mut animated: Query<(&mut Transform, &Rotating)
         let angle = time % period / period * TAU64;
         let rot = Quat::from_rotation_y(angle as f32);
         trans.rotation = Quat::from_rotation_y(TAU / 4.1) * rot;
+    }
+}
+
+fn move_camera(input: Res<Input<KeyCode>>, mut camera: Query<&mut Transform, With<Camera>>) {
+    if let Ok(mut camera_transform) = camera.get_single_mut() {
+        let trans = &mut camera_transform.translation;
+        let go_forward = input.any_pressed([KeyCode::Up, KeyCode::I, KeyCode::W]);
+        let go_backward = input.any_pressed([KeyCode::Down, KeyCode::K, KeyCode::S]);
+        if go_forward && trans.x > 10.0 {
+            trans.x -= 2.0;
+        } else if go_backward && trans.x < 500.0 {
+            trans.x += 2.0;
+        }
     }
 }
 fn setup(
@@ -43,7 +71,7 @@ fn setup(
     .insert(Rotating(30.0));
     let top = Vec3::Y * 100.0;
     let bottom = Vec3::Y * -100.0;
-    // Show the middle point as a vertical red bar.
+    // Show the middle as a vertical red bar.
     cmds.spawn_bundle(PolylineBundle {
         polyline: polylines.add(Polyline {
             vertices: vec![top, bottom],
@@ -57,7 +85,7 @@ fn setup(
         }),
         ..Default::default()
     });
-    // Evaluate how "deep" the depth_bias makes the line change
+    // Draw from bottom to top, red to purple, -1.0 to 1.0 horizontal lines
     for i in 0..100 {
         let bias = (i as f32) / 50.0 - 1.0;
         let left = Vec3::new(0.0, bias * 35.0, -500.0);

--- a/src/material.rs
+++ b/src/material.rs
@@ -28,8 +28,28 @@ use std::fmt::Debug;
 #[derive(Component, Debug, PartialEq, Clone, Copy, TypeUuid)]
 #[uuid = "69b87497-2ba0-4c38-ba82-f54bf1ffe873"]
 pub struct PolylineMaterial {
+    /// Width of the line.
+    ///
+    /// Corresponds to screen pixels when line is positioned nearest the
+    /// camera.
     pub width: f32,
     pub color: Color,
+    /// How closer to the camera than real geometry the line should be.
+    ///
+    /// Value between -1 and 1 (inclusive).
+    /// * 0 means that there is no change to the line position when rendering
+    /// * 1 means it is furthest away from camera as possible
+    /// * -1 means that it will always render in front of other things.
+    ///
+    /// This is typically useful if you are drawing wireframes on top of polygons
+    /// and your wireframe is z-fighting (flickering on/off) with your main model.
+    /// You would set this value to a negative number close to 0.0.
+    pub depth_bias: f32,
+    /// Whether to reduce line width with perspective
+    ///
+    /// When `perspective` is `true`, `width` gets divided by the w component of
+    /// the homogeneous coordinate, meaning it corresponds to screen pixels at
+    /// the near plane and becomes progressively smaller further away.
     pub perspective: bool,
 }
 
@@ -38,6 +58,7 @@ impl Default for PolylineMaterial {
         Self {
             width: 10.0,
             color: Color::WHITE,
+            depth_bias: 0.0,
             perspective: false,
         }
     }
@@ -85,6 +106,7 @@ impl PolylineMaterial {
 #[derive(AsStd140, Component, Clone)]
 pub struct PolylineMaterialUniform {
     pub color: Vec4,
+    pub depth_bias: f32,
     pub width: f32,
 }
 
@@ -113,6 +135,7 @@ impl RenderAsset for PolylineMaterial {
     > {
         let value = PolylineMaterialUniform {
             width: material.width,
+            depth_bias: material.depth_bias,
             color: material.color.as_linear_rgba_f32().into(),
         };
         let value_std140 = value.as_std140();

--- a/src/material.rs
+++ b/src/material.rs
@@ -45,11 +45,16 @@ pub struct PolylineMaterial {
     /// and your wireframe is z-fighting (flickering on/off) with your main model.
     /// You would set this value to a negative number close to 0.0.
     pub depth_bias: f32,
-    /// Whether to reduce line width with perspective
+    /// Whether to reduce line width with perspective.
     ///
-    /// When `perspective` is `true`, `width` gets divided by the w component of
-    /// the homogeneous coordinate, meaning it corresponds to screen pixels at
-    /// the near plane and becomes progressively smaller further away.
+    /// When `perspective` is `true`, `width` corresponds to screen pixels at
+    /// the near plane and becomes progressively smaller further away. This is done
+    /// by dividing `width` by the w component of the homogeneous coordinate.
+    ///
+    /// If the width where to be lower than 1, the color of the line is faded. This
+    /// prevents flickering.
+    ///
+    /// Note that `depth_bias` **does not** interact with this in any way.
     pub perspective: bool,
 }
 

--- a/src/shaders/polyline.wgsl
+++ b/src/shaders/polyline.wgsl
@@ -23,6 +23,7 @@ var<uniform> polyline: Polyline;
 
 struct PolylineMaterial {
     color: vec4<f32>;
+    depth_bias: f32;
     width: f32;
 };
 
@@ -83,7 +84,12 @@ fn vertex(vertex: Vertex) -> VertexOutput {
     let pt1 = screen1 + line_width * (position.x * xBasis + position.y * yBasis);
     let pt = mix(pt0, pt1, position.z);
 
-    let depth = clip.z;
+    var depth: f32 = clip.z;
+    if (material.depth_bias >= 0.0) {
+         depth = depth * (1.0 - material.depth_bias);
+    } else {
+         depth = depth * exp2(-material.depth_bias * 8.9);
+     }
 
     return VertexOutput(vec4<f32>(clip.w * ((2.0 * pt) / resolution - 1.0), depth, clip.w), color);
 };


### PR DESCRIPTION
This let the user draw lines closer or further away from the camera
than the line is really in the 3d world.

A good use case for this is making the lines draw always in front of
geometry, or slightly offsetting the line so they can be shown in front
of geometry it shares with other things.

Closes #25.

Note on `perspective`: I would like to keep the ability to set/unset the `perspective` independently from the `depth_bias`. Perspective is a good way to see "where" a line should be even when it always show up in front of other things.