### PR TITLE
Reduce dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,9 @@ authors = [
 [dependencies]
 bitflags = "1.3"
 bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
-    "render",
+    "bevy_core_pipeline",
+    "bevy_render",
+    "bevy_pbr",
     "bevy_asset",
 ] }
 


### PR DESCRIPTION
Previously used `render` feature is a [group](
https://github.com/bevyengine/bevy/blob/a291b5aaedb4affcb31df2e2e63cb0c665ffb24a/Cargo.toml#L35-L43) that contains unneeded stuff, like `bevy_ui` or `bevy_text`. Specified features in this PR is the required minimum. You can read more about in in this issue: https://github.com/bevyengine/bevy/issues/4202 and also see https://github.com/bevyengine/bevy/issues/5753