### PR TITLE
Update for Bevy 0.13.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ authors = [
 
 [dependencies]
 bitflags = "2.3"
-bevy = { version = "0.12", default-features = false, features = [
+bevy = { version = "0.13", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_render",
     "bevy_asset",
@@ -26,13 +26,13 @@ bevy = { version = "0.12", default-features = false, features = [
 
 [dependencies.naga]
 features = ["glsl-in", "spv-out", "wgsl-out"]
-version = "0.13"
+version = "0.19"
 
 [dev-dependencies]
 lazy_static = "1.4.0"
 rand = "0.8.4"
 ringbuffer = "0.15"
-bevy = { version = "0.12", default-features = false, features = [
+bevy = { version = "0.13", default-features = false, features = [
     "bevy_winit",
     "bevy_pbr",
     "x11",

--- a/examples/depth_bias.rs
+++ b/examples/depth_bias.rs
@@ -1,6 +1,7 @@
 use std::f32::consts::TAU;
 use std::f64::consts::TAU as TAU64;
 
+use bevy::math::vec3;
 use bevy::prelude::*;
 use bevy_polyline::prelude::*;
 
@@ -41,11 +42,11 @@ fn rotate_plane(time: Res<Time>, mut animated: Query<(&mut Transform, &Rotating)
     }
 }
 
-fn move_camera(input: Res<Input<KeyCode>>, mut camera: Query<&mut Transform, With<Camera>>) {
+fn move_camera(input: Res<ButtonInput<KeyCode>>, mut camera: Query<&mut Transform, With<Camera>>) {
     if let Ok(mut camera_transform) = camera.get_single_mut() {
         let trans = &mut camera_transform.translation;
-        let go_forward = input.any_pressed([KeyCode::Up, KeyCode::I, KeyCode::W]);
-        let go_backward = input.any_pressed([KeyCode::Down, KeyCode::K, KeyCode::S]);
+        let go_forward = input.any_pressed([KeyCode::ArrowUp, KeyCode::KeyI, KeyCode::KeyW]);
+        let go_backward = input.any_pressed([KeyCode::ArrowDown, KeyCode::KeyK, KeyCode::KeyS]);
         if go_forward && trans.x > 10.0 {
             trans.x -= 2.0;
         } else if go_backward && trans.x < 500.0 {
@@ -65,8 +66,8 @@ fn setup(
         .insert(Transform::from_xyz(100.0, 0.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y));
     commands.spawn((
         PbrBundle {
-            mesh: meshes.add(shape::Box::new(0.01, 100.0, 10000.0).into()),
-            material: pbr_materials.add(Color::WHITE.into()),
+            mesh: meshes.add(Mesh::from(Cuboid::from_size(vec3(0.01, 100.0, 10000.0)))),
+            material: pbr_materials.add(StandardMaterial::from(Color::WHITE)),
             ..default()
         },
         Rotating(30.0),

--- a/examples/linestrip.rs
+++ b/examples/linestrip.rs
@@ -42,16 +42,16 @@ fn setup(
     });
 
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Plane::from_size(5.0))),
-        material: standard_materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        mesh: meshes.add(Mesh::from(Plane3d::new(Vec3::Y))),
+        material: standard_materials.add(StandardMaterial::from(Color::rgb(0.3, 0.5, 0.3))),
         transform: Transform::from_xyz(0.0, -0.5, 0.0),
         ..Default::default()
     });
 
     // cube
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-        material: standard_materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        mesh: meshes.add(Mesh::from(Cuboid::from_size(Vec3::splat(1.0)))),
+        material: standard_materials.add(StandardMaterial::from(Color::rgb(0.8, 0.7, 0.6))),
         ..Default::default()
     });
 

--- a/examples/nbody.rs
+++ b/examples/nbody.rs
@@ -205,7 +205,7 @@ fn update_trails(
     mut polylines: ResMut<Assets<Polyline>>,
     mut query: Query<(&Body, &mut Trail, &Handle<Polyline>)>,
 ) {
-    query.for_each_mut(|(body, mut trail, polyline)| {
+    for (body, mut trail, polyline) in &mut query {
         if let Some(position) = trail.0.back() {
             let last_vec = *position - body.position;
             let last_last_vec = if let Some(position) = trail.0.get_signed(-2) {
@@ -235,7 +235,7 @@ fn update_trails(
             polylines.get_mut(polyline).unwrap().vertices =
                 trail.0.iter().map(|v| Vec3::from(*v)).collect()
         }
-    });
+    }
 }
 
 lazy_static! {

--- a/examples/perspective.rs
+++ b/examples/perspective.rs
@@ -41,28 +41,28 @@ fn setup(
 
 fn move_camera(
     mut q: Query<&mut Transform, With<Camera>>,
-    keyboard_input: Res<Input<KeyCode>>,
+    keyboard_input: Res<ButtonInput<KeyCode>>,
     time: Res<Time>,
 ) {
     let speed = 5.0;
     for mut t in &mut q {
         let mut dir = Vec3::ZERO;
-        if keyboard_input.pressed(KeyCode::W) {
+        if keyboard_input.pressed(KeyCode::KeyW) {
             dir.z -= 1.0;
         }
-        if keyboard_input.pressed(KeyCode::S) {
+        if keyboard_input.pressed(KeyCode::KeyS) {
             dir.z += 1.0;
         }
-        if keyboard_input.pressed(KeyCode::A) {
+        if keyboard_input.pressed(KeyCode::KeyA) {
             dir.x -= 1.0;
         }
-        if keyboard_input.pressed(KeyCode::D) {
+        if keyboard_input.pressed(KeyCode::KeyD) {
             dir.x += 1.0;
         }
-        if keyboard_input.pressed(KeyCode::Q) {
+        if keyboard_input.pressed(KeyCode::KeyQ) {
             dir.y -= 1.0;
         }
-        if keyboard_input.pressed(KeyCode::E) {
+        if keyboard_input.pressed(KeyCode::KeyE) {
             dir.y += 1.0;
         }
         t.translation += dir * time.delta_seconds() * speed;
@@ -71,10 +71,10 @@ fn move_camera(
 
 fn toggle_perspective(
     mut polyline_materials: ResMut<Assets<PolylineMaterial>>,
-    keyboard_input: Res<Input<KeyCode>>,
+    keyboard_input: Res<ButtonInput<KeyCode>>,
 ) {
     for (_, mat) in polyline_materials.iter_mut() {
-        if keyboard_input.just_pressed(KeyCode::X) {
+        if keyboard_input.just_pressed(KeyCode::KeyX) {
             mat.perspective = !mat.perspective;
         }
     }

--- a/src/material.rs
+++ b/src/material.rs
@@ -13,10 +13,12 @@ use bevy::{
         },
     },
     prelude::*,
-    reflect::{TypePath, TypeUuid},
+    reflect::TypePath,
     render::{
         extract_component::ExtractComponentPlugin,
-        render_asset::{RenderAsset, RenderAssetPlugin, RenderAssets},
+        render_asset::{
+            PrepareAssetError, RenderAsset, RenderAssetPlugin, RenderAssetUsages, RenderAssets,
+        },
         render_phase::*,
         render_resource::*,
         renderer::{RenderDevice, RenderQueue},
@@ -26,8 +28,7 @@ use bevy::{
 };
 use std::fmt::Debug;
 
-#[derive(Asset, Debug, PartialEq, Clone, Copy, TypeUuid, TypePath)]
-#[uuid = "69b87497-2ba0-4c38-ba82-f54bf1ffe873"]
+#[derive(Asset, Debug, PartialEq, Clone, Copy, TypePath)]
 pub struct PolylineMaterial {
     /// Width of the line.
     ///
@@ -72,8 +73,9 @@ impl Default for PolylineMaterial {
 
 impl PolylineMaterial {
     pub fn bind_group_layout(render_device: &RenderDevice) -> BindGroupLayout {
-        render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-            entries: &[BindGroupLayoutEntry {
+        render_device.create_bind_group_layout(
+            "polyline_material_layout",
+            &[BindGroupLayoutEntry {
                 binding: 0,
                 visibility: ShaderStages::VERTEX,
                 ty: BindingType::Buffer {
@@ -83,8 +85,7 @@ impl PolylineMaterial {
                 },
                 count: None,
             }],
-            label: Some("polyline_material_layout"),
-        })
+        )
     }
 
     #[inline]
@@ -114,7 +115,6 @@ pub struct GpuPolylineMaterial {
 }
 
 impl RenderAsset for PolylineMaterial {
-    type ExtractedAsset = PolylineMaterial;
     type PreparedAsset = GpuPolylineMaterial;
     type Param = (
         SRes<RenderDevice>,
@@ -122,21 +122,14 @@ impl RenderAsset for PolylineMaterial {
         SRes<PolylineMaterialPipeline>,
     );
 
-    fn extract_asset(&self) -> Self::ExtractedAsset {
-        *self
-    }
-
     fn prepare_asset(
-        material: Self::ExtractedAsset,
+        self,
         (device, queue, polyline_pipeline): &mut bevy::ecs::system::SystemParamItem<Self::Param>,
-    ) -> Result<
-        Self::PreparedAsset,
-        bevy::render::render_asset::PrepareAssetError<Self::ExtractedAsset>,
-    > {
+    ) -> Result<Self::PreparedAsset, PrepareAssetError<Self>> {
         let value = PolylineMaterialUniform {
-            width: material.width,
-            depth_bias: material.depth_bias,
-            color: material.color.as_linear_rgba_f32().into(),
+            width: self.width,
+            depth_bias: self.depth_bias,
+            color: self.color.as_linear_rgba_f32().into(),
         };
 
         let mut buffer = UniformBuffer::from(value);
@@ -151,7 +144,7 @@ impl RenderAsset for PolylineMaterial {
             }],
         );
 
-        let alpha_mode = if material.color.a() < 1.0 {
+        let alpha_mode = if self.color.a() < 1.0 {
             AlphaMode::Blend
         } else {
             AlphaMode::Opaque
@@ -159,10 +152,14 @@ impl RenderAsset for PolylineMaterial {
 
         Ok(GpuPolylineMaterial {
             buffer,
-            perspective: material.perspective,
+            perspective: self.perspective,
             alpha_mode,
             bind_group,
         })
+    }
+
+    fn asset_usage(&self) -> RenderAssetUsages {
+        RenderAssetUsages::RENDER_WORLD
     }
 }
 
@@ -237,15 +234,15 @@ type DrawMaterial = (
 
 pub struct SetPolylineViewBindGroup<const I: usize>;
 impl<const I: usize, P: PhaseItem> RenderCommand<P> for SetPolylineViewBindGroup<I> {
-    type ViewWorldQuery = (Read<ViewUniformOffset>, Read<PolylineViewBindGroup>);
-    type ItemWorldQuery = ();
+    type ViewQuery = (Read<ViewUniformOffset>, Read<PolylineViewBindGroup>);
+    type ItemQuery = ();
     type Param = ();
 
     #[inline]
     fn render<'w>(
         _item: &P,
-        (view_uniform, mesh_view_bind_group): ROQueryItem<'w, Self::ViewWorldQuery>,
-        _entity: ROQueryItem<'w, Self::ItemWorldQuery>,
+        (view_uniform, mesh_view_bind_group): ROQueryItem<'w, Self::ViewQuery>,
+        _entity: Option<Self::ItemQuery>,
         _param: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
@@ -256,18 +253,21 @@ impl<const I: usize, P: PhaseItem> RenderCommand<P> for SetPolylineViewBindGroup
 
 pub struct SetMaterialBindGroup<const I: usize>;
 impl<const I: usize, P: PhaseItem> RenderCommand<P> for SetMaterialBindGroup<I> {
-    type ViewWorldQuery = ();
-    type ItemWorldQuery = Read<Handle<PolylineMaterial>>;
+    type ViewQuery = ();
+    type ItemQuery = Read<Handle<PolylineMaterial>>;
     type Param = SRes<RenderAssets<PolylineMaterial>>;
 
     fn render<'w>(
         _item: &P,
-        _view: ROQueryItem<'w, Self::ViewWorldQuery>,
-        material_handle: ROQueryItem<'w, Self::ItemWorldQuery>,
+        _view: ROQueryItem<'w, Self::ViewQuery>,
+        material_handle: Option<ROQueryItem<'w, Self::ItemQuery>>,
         materials: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
-        let material = materials.into_inner().get(material_handle).unwrap();
+        let material = materials
+            .into_inner()
+            .get(material_handle.unwrap())
+            .unwrap();
         pass.set_bind_group(
             I,
             PolylineMaterial::bind_group(material),
@@ -339,13 +339,9 @@ pub fn queue_material_polylines(
                                 entity: *visible_entity,
                                 draw_function: draw_opaque,
                                 pipeline: pipeline_id,
-                                // NOTE: Front-to-back ordering for opaque with ascending sort means near should have the
-                                // lowest sort key and getting further away should increase. As we have
-                                // -z in front of the camera, values in view space decrease away from the
-                                // camera. Flipping the sign of mesh_z results in the correct front-to-back ordering
-                                distance: -polyline_z,
                                 batch_range: 0..1,
                                 dynamic_offset: None,
+                                asset_id: todo!("What mesh goes here?"),
                             });
                         }
                         AlphaMode::Mask(_) => {


### PR DESCRIPTION
I made a quick attempt to update to Bevy 0.13.

Most of the things were obvious API changes, renames and such. I have no experience with this code, so the one unresolved question is:

1. in src/material.rs:344, `Opaque3d` now requires an `asset_id`, but it's not obvious to me what `Mesh` asset should be put here so I put a `todo!()`.

Of the things that I've changed, the only concern I have is that I have  `asset_usage()` returning `RENDER_WORLD` only, but this I can test once I figure out what to do with `Opaque3d`.