### PR TITLE
updated to work with bevy 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ authors = [
 ]
 
 [dependencies]
-bitflags = "2.3"
-bevy = { version = "0.12", default-features = false, features = [
+bitflags = "2.4"
+bevy = { version = "0.13", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_render",
     "bevy_asset",
@@ -32,7 +32,7 @@ version = "0.13"
 lazy_static = "1.4.0"
 rand = "0.8.4"
 ringbuffer = "0.15"
-bevy = { version = "0.12", default-features = false, features = [
+bevy = { version = "0.13", default-features = false, features = [
     "bevy_winit",
     "bevy_pbr",
     "x11",

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ We intend to track the `main` branch of Bevy. PRs supporting this are welcome!
 
 | bevy | bevy_polyline |
 | ---- | ------------- |
+| 0.13 | 0.13          |
 | 0.12 | 0.8           |
 | 0.11 | 0.7           |
 | 0.10 | 0.5, 0.6      |

--- a/examples/depth_bias.rs
+++ b/examples/depth_bias.rs
@@ -41,11 +41,11 @@ fn rotate_plane(time: Res<Time>, mut animated: Query<(&mut Transform, &Rotating)
     }
 }
 
-fn move_camera(input: Res<Input<KeyCode>>, mut camera: Query<&mut Transform, With<Camera>>) {
+fn move_camera(input: Res<ButtonInput<KeyCode>>, mut camera: Query<&mut Transform, With<Camera>>) {
     if let Ok(mut camera_transform) = camera.get_single_mut() {
         let trans = &mut camera_transform.translation;
-        let go_forward = input.any_pressed([KeyCode::Up, KeyCode::I, KeyCode::W]);
-        let go_backward = input.any_pressed([KeyCode::Down, KeyCode::K, KeyCode::S]);
+        let go_forward = input.any_pressed([KeyCode::ArrowUp, KeyCode::KeyI, KeyCode::KeyW]);
+        let go_backward = input.any_pressed([KeyCode::ArrowDown, KeyCode::KeyK, KeyCode::KeyS]);
         if go_forward && trans.x > 10.0 {
             trans.x -= 2.0;
         } else if go_backward && trans.x < 500.0 {
@@ -65,8 +65,11 @@ fn setup(
         .insert(Transform::from_xyz(100.0, 0.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y));
     commands.spawn((
         PbrBundle {
-            mesh: meshes.add(shape::Box::new(0.01, 100.0, 10000.0).into()),
-            material: pbr_materials.add(Color::WHITE.into()),
+            mesh: meshes.add( Cuboid::new(0.01, 100.0, 10000.0)),
+            material: pbr_materials.add(StandardMaterial {
+                base_color: Color::WHITE.into(),
+                ..Default::default()
+            }),
             ..default()
         },
         Rotating(30.0),

--- a/examples/linestrip.rs
+++ b/examples/linestrip.rs
@@ -42,16 +42,22 @@ fn setup(
     });
 
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Plane::from_size(5.0))),
-        material: standard_materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        mesh: meshes.add(Mesh::from( Plane3d::new(Vec3::Y))),
+        material: standard_materials.add(StandardMaterial {
+            base_color: Color::rgb(0.3, 0.5, 0.3),
+            ..Default::default()
+        }),
         transform: Transform::from_xyz(0.0, -0.5, 0.0),
         ..Default::default()
     });
 
     // cube
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-        material: standard_materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        mesh: meshes.add(Mesh::from(Cuboid::new(1.0, 1.0, 1.0))),
+        material: standard_materials.add(StandardMaterial {
+            base_color: Color::rgb(0.8, 0.7, 0.6),
+            ..Default::default()
+        }),
         ..Default::default()
     });
 

--- a/examples/nbody.rs
+++ b/examples/nbody.rs
@@ -205,7 +205,7 @@ fn update_trails(
     mut polylines: ResMut<Assets<Polyline>>,
     mut query: Query<(&Body, &mut Trail, &Handle<Polyline>)>,
 ) {
-    query.for_each_mut(|(body, mut trail, polyline)| {
+    for (body, mut trail, polyline) in &mut query {
         if let Some(position) = trail.0.back() {
             let last_vec = *position - body.position;
             let last_last_vec = if let Some(position) = trail.0.get_signed(-2) {
@@ -235,7 +235,7 @@ fn update_trails(
             polylines.get_mut(polyline).unwrap().vertices =
                 trail.0.iter().map(|v| Vec3::from(*v)).collect()
         }
-    });
+    }
 }
 
 lazy_static! {

--- a/examples/perspective.rs
+++ b/examples/perspective.rs
@@ -41,28 +41,28 @@ fn setup(
 
 fn move_camera(
     mut q: Query<&mut Transform, With<Camera>>,
-    keyboard_input: Res<Input<KeyCode>>,
+    keyboard_input: Res<ButtonInput<KeyCode>>,
     time: Res<Time>,
 ) {
     let speed = 5.0;
     for mut t in &mut q {
         let mut dir = Vec3::ZERO;
-        if keyboard_input.pressed(KeyCode::W) {
+        if keyboard_input.pressed(KeyCode::KeyW) {
             dir.z -= 1.0;
         }
-        if keyboard_input.pressed(KeyCode::S) {
+        if keyboard_input.pressed(KeyCode::KeyS) {
             dir.z += 1.0;
         }
-        if keyboard_input.pressed(KeyCode::A) {
+        if keyboard_input.pressed(KeyCode::KeyA) {
             dir.x -= 1.0;
         }
-        if keyboard_input.pressed(KeyCode::D) {
+        if keyboard_input.pressed(KeyCode::KeyD) {
             dir.x += 1.0;
         }
-        if keyboard_input.pressed(KeyCode::Q) {
+        if keyboard_input.pressed(KeyCode::KeyQ) {
             dir.y -= 1.0;
         }
-        if keyboard_input.pressed(KeyCode::E) {
+        if keyboard_input.pressed(KeyCode::KeyE) {
             dir.y += 1.0;
         }
         t.translation += dir * time.delta_seconds() * speed;
@@ -71,10 +71,10 @@ fn move_camera(
 
 fn toggle_perspective(
     mut polyline_materials: ResMut<Assets<PolylineMaterial>>,
-    keyboard_input: Res<Input<KeyCode>>,
+    keyboard_input: Res<ButtonInput<KeyCode>>,
 ) {
     for (_, mat) in polyline_materials.iter_mut() {
-        if keyboard_input.just_pressed(KeyCode::X) {
+        if keyboard_input.just_pressed(KeyCode::KeyX) {
             mat.perspective = !mat.perspective;
         }
     }

--- a/src/material.rs
+++ b/src/material.rs
@@ -13,10 +13,10 @@ use bevy::{
         },
     },
     prelude::*,
-    reflect::{TypePath, TypeUuid},
+    reflect::TypePath,
     render::{
         extract_component::ExtractComponentPlugin,
-        render_asset::{RenderAsset, RenderAssetPlugin, RenderAssets},
+        render_asset::{PrepareAssetError, RenderAsset, RenderAssetPlugin, RenderAssetUsages, RenderAssets},
         render_phase::*,
         render_resource::*,
         renderer::{RenderDevice, RenderQueue},
@@ -26,8 +26,9 @@ use bevy::{
 };
 use std::fmt::Debug;
 
-#[derive(Asset, Debug, PartialEq, Clone, Copy, TypeUuid, TypePath)]
-#[uuid = "69b87497-2ba0-4c38-ba82-f54bf1ffe873"]
+// #[derive(Asset, Debug, PartialEq, Clone, Copy, TypeUuid, TypePath)]
+// #[uuid = "69b87497-2ba0-4c38-ba82-f54bf1ffe873"]
+#[derive(Asset, Debug, PartialEq, Clone, Copy, TypePath)]
 pub struct PolylineMaterial {
     /// Width of the line.
     ///
@@ -72,8 +73,9 @@ impl Default for PolylineMaterial {
 
 impl PolylineMaterial {
     pub fn bind_group_layout(render_device: &RenderDevice) -> BindGroupLayout {
-        render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-            entries: &[BindGroupLayoutEntry {
+        render_device.create_bind_group_layout(
+            Some("polyline_material_layout"),
+            &[BindGroupLayoutEntry {
                 binding: 0,
                 visibility: ShaderStages::VERTEX,
                 ty: BindingType::Buffer {
@@ -82,9 +84,8 @@ impl PolylineMaterial {
                     min_binding_size: BufferSize::new(PolylineMaterialUniform::min_size().into()),
                 },
                 count: None,
-            }],
-            label: Some("polyline_material_layout"),
-        })
+            }]
+        )
     }
 
     #[inline]
@@ -114,7 +115,7 @@ pub struct GpuPolylineMaterial {
 }
 
 impl RenderAsset for PolylineMaterial {
-    type ExtractedAsset = PolylineMaterial;
+    // type ExtractedAsset = PolylineMaterial;
     type PreparedAsset = GpuPolylineMaterial;
     type Param = (
         SRes<RenderDevice>,
@@ -122,21 +123,21 @@ impl RenderAsset for PolylineMaterial {
         SRes<PolylineMaterialPipeline>,
     );
 
-    fn extract_asset(&self) -> Self::ExtractedAsset {
-        *self
+    fn asset_usage(&self) -> RenderAssetUsages {
+        RenderAssetUsages::MAIN_WORLD | RenderAssetUsages::RENDER_WORLD
     }
 
     fn prepare_asset(
-        material: Self::ExtractedAsset,
-        (device, queue, polyline_pipeline): &mut bevy::ecs::system::SystemParamItem<Self::Param>,
+        self,
+        (device, queue, polyline_pipeline): &mut SystemParamItem<Self::Param>,
     ) -> Result<
         Self::PreparedAsset,
-        bevy::render::render_asset::PrepareAssetError<Self::ExtractedAsset>,
+        PrepareAssetError<Self>,
     > {
         let value = PolylineMaterialUniform {
-            width: material.width,
-            depth_bias: material.depth_bias,
-            color: material.color.as_linear_rgba_f32().into(),
+            width: self.width,
+            depth_bias: self.depth_bias,
+            color: self.color.as_linear_rgba_f32().into(),
         };
 
         let mut buffer = UniformBuffer::from(value);
@@ -151,7 +152,7 @@ impl RenderAsset for PolylineMaterial {
             }],
         );
 
-        let alpha_mode = if material.color.a() < 1.0 {
+        let alpha_mode = if self.color.a() < 1.0 {
             AlphaMode::Blend
         } else {
             AlphaMode::Opaque
@@ -159,7 +160,7 @@ impl RenderAsset for PolylineMaterial {
 
         Ok(GpuPolylineMaterial {
             buffer,
-            perspective: material.perspective,
+            perspective: self.perspective,
             alpha_mode,
             bind_group,
         })
@@ -237,15 +238,15 @@ type DrawMaterial = (
 
 pub struct SetPolylineViewBindGroup<const I: usize>;
 impl<const I: usize, P: PhaseItem> RenderCommand<P> for SetPolylineViewBindGroup<I> {
-    type ViewWorldQuery = (Read<ViewUniformOffset>, Read<PolylineViewBindGroup>);
-    type ItemWorldQuery = ();
+    type ViewQuery = (Read<ViewUniformOffset>, Read<PolylineViewBindGroup>);
+    type ItemQuery = ();
     type Param = ();
 
     #[inline]
     fn render<'w>(
         _item: &P,
-        (view_uniform, mesh_view_bind_group): ROQueryItem<'w, Self::ViewWorldQuery>,
-        _entity: ROQueryItem<'w, Self::ItemWorldQuery>,
+        (view_uniform, mesh_view_bind_group): ROQueryItem<'w, Self::ViewQuery>,
+        _entity: Option<ROQueryItem<'w, Self::ItemQuery>>,
         _param: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
@@ -256,18 +257,19 @@ impl<const I: usize, P: PhaseItem> RenderCommand<P> for SetPolylineViewBindGroup
 
 pub struct SetMaterialBindGroup<const I: usize>;
 impl<const I: usize, P: PhaseItem> RenderCommand<P> for SetMaterialBindGroup<I> {
-    type ViewWorldQuery = ();
-    type ItemWorldQuery = Read<Handle<PolylineMaterial>>;
+    type ViewQuery = ();
+    type ItemQuery = Read<Handle<PolylineMaterial>>;
     type Param = SRes<RenderAssets<PolylineMaterial>>;
 
     fn render<'w>(
         _item: &P,
-        _view: ROQueryItem<'w, Self::ViewWorldQuery>,
-        material_handle: ROQueryItem<'w, Self::ItemWorldQuery>,
+        _view: ROQueryItem<'w, Self::ViewQuery>,
+        material_handle: Option<ROQueryItem<'w, Self::ItemQuery>>,
         materials: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
-        let material = materials.into_inner().get(material_handle).unwrap();
+        let mat_handle = material_handle.unwrap();
+        let material = materials.into_inner().get(mat_handle).unwrap();
         pass.set_bind_group(
             I,
             PolylineMaterial::bind_group(material),
@@ -343,7 +345,8 @@ pub fn queue_material_polylines(
                                 // lowest sort key and getting further away should increase. As we have
                                 // -z in front of the camera, values in view space decrease away from the
                                 // camera. Flipping the sign of mesh_z results in the correct front-to-back ordering
-                                distance: -polyline_z,
+                                //distance: -polyline_z,
+                                asset_id: AssetId::default(), // TODO: this is probably wrong
                                 batch_range: 0..1,
                                 dynamic_offset: None,
                             });

--- a/src/polyline.rs
+++ b/src/polyline.rs
@@ -9,10 +9,10 @@ use bevy::{
         },
     },
     prelude::*,
-    reflect::{TypePath, TypeUuid},
+    reflect::TypePath,
     render::{
         extract_component::{ComponentUniforms, DynamicUniformIndex, UniformComponentPlugin},
-        render_asset::{RenderAsset, RenderAssetPlugin, RenderAssets},
+        render_asset::{PrepareAssetError, RenderAsset, RenderAssetPlugin, RenderAssetUsages, RenderAssets},
         render_phase::{PhaseItem, RenderCommand, RenderCommandResult, TrackedRenderPass},
         render_resource::*,
         renderer::RenderDevice,
@@ -64,32 +64,34 @@ pub struct PolylineBundle {
     pub view_visibility: ViewVisibility,
 }
 
-#[derive(Debug, Default, Asset, Clone, TypeUuid, TypePath)]
-#[uuid = "c76af88a-8afe-405c-9a64-0a7d845d2546"]
+#[derive(Debug, Default, Asset, Clone, TypePath)]
+// #[derive(Debug, Default, Asset, Clone, TypeUuid, TypePath)]
+// #[uuid = "c76af88a-8afe-405c-9a64-0a7d845d2546"]
 pub struct Polyline {
     pub vertices: Vec<Vec3>,
 }
 
 impl RenderAsset for Polyline {
-    type ExtractedAsset = Polyline;
+    // type ExtractedAsset = Polyline;
 
     type PreparedAsset = GpuPolyline;
 
     type Param = SRes<RenderDevice>;
 
-    fn extract_asset(&self) -> Self::ExtractedAsset {
-        self.clone()
+    // fn extract_asset(&self) -> Self::ExtractedAsset {
+    //     self.clone()
+    // }
+
+    fn asset_usage(&self) -> RenderAssetUsages {
+        RenderAssetUsages::RENDER_WORLD | RenderAssetUsages::MAIN_WORLD
     }
 
     fn prepare_asset(
-        polyline: Self::ExtractedAsset,
-        render_device: &mut bevy::ecs::system::SystemParamItem<Self::Param>,
-    ) -> Result<
-        Self::PreparedAsset,
-        bevy::render::render_asset::PrepareAssetError<Self::ExtractedAsset>,
-    > {
-        let vertex_buffer_data = cast_slice(polyline.vertices.as_slice());
-        let vertex_buffer = render_device.create_buffer_with_data(&BufferInitDescriptor {
+            self,
+            param: &mut SystemParamItem<Self::Param>,
+        ) -> Result<Self::PreparedAsset, PrepareAssetError<Self>> {
+        let vertex_buffer_data = cast_slice(self.vertices.as_slice());
+        let vertex_buffer = param.create_buffer_with_data(&BufferInitDescriptor {
             usage: BufferUsages::VERTEX,
             label: Some("Polyline Vertex Buffer"),
             contents: vertex_buffer_data,
@@ -97,7 +99,7 @@ impl RenderAsset for Polyline {
 
         Ok(GpuPolyline {
             vertex_buffer,
-            vertex_count: polyline.vertices.len() as u32,
+            vertex_count: self.vertices.len() as u32,
         })
     }
 }
@@ -159,8 +161,9 @@ pub struct PolylinePipeline {
 impl FromWorld for PolylinePipeline {
     fn from_world(world: &mut World) -> Self {
         let render_device = world.get_resource::<RenderDevice>().unwrap();
-        let view_layout = render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-            entries: &[
+        let view_layout = render_device.create_bind_group_layout(
+            Some("polyline_view_layout"),
+            &[
                 // View
                 BindGroupLayoutEntry {
                     binding: 0,
@@ -173,11 +176,11 @@ impl FromWorld for PolylinePipeline {
                     count: None,
                 },
             ],
-            label: Some("polyline_view_layout"),
-        });
+        );
 
-        let polyline_layout = render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-            entries: &[BindGroupLayoutEntry {
+        let polyline_layout = render_device.create_bind_group_layout(
+            Some("polyline_layout"),
+            &[BindGroupLayoutEntry {
                 binding: 0,
                 visibility: ShaderStages::VERTEX,
                 ty: BindingType::Buffer {
@@ -187,8 +190,7 @@ impl FromWorld for PolylinePipeline {
                 },
                 count: None,
             }],
-            label: Some("polyline_layout"),
-        });
+        );
 
         PolylinePipeline {
             view_layout,
@@ -397,38 +399,41 @@ pub fn prepare_polyline_view_bind_groups(
 
 pub struct SetPolylineBindGroup<const I: usize>;
 impl<const I: usize, P: PhaseItem> RenderCommand<P> for SetPolylineBindGroup<I> {
-    type ViewWorldQuery = ();
-    type ItemWorldQuery = Read<DynamicUniformIndex<PolylineUniform>>;
+    type ViewQuery = ();
+    type ItemQuery = Read<DynamicUniformIndex<PolylineUniform>>;
     type Param = SRes<PolylineBindGroup>;
 
     #[inline]
     fn render<'w>(
         _item: &P,
-        _view: ROQueryItem<'w, Self::ViewWorldQuery>,
-        polyline_index: ROQueryItem<'w, Self::ItemWorldQuery>,
+        _view: ROQueryItem<'w, Self::ViewQuery>,
+        polyline_index: Option<ROQueryItem<'w, Self::ItemQuery>>,
         bind_group: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
-        pass.set_bind_group(I, &bind_group.into_inner().value, &[polyline_index.index()]);
+        let Some(pl_idx) = polyline_index else { return RenderCommandResult::Failure };
+        pass.set_bind_group(I, &bind_group.into_inner().value, &[pl_idx.index()]);
         RenderCommandResult::Success
     }
+
 }
 
 pub struct DrawPolyline;
 impl<P: PhaseItem> RenderCommand<P> for DrawPolyline {
-    type ViewWorldQuery = ();
-    type ItemWorldQuery = Read<Handle<Polyline>>;
+    type ViewQuery = ();
+    type ItemQuery = Read<Handle<Polyline>>;
     type Param = SRes<RenderAssets<Polyline>>;
 
     #[inline]
     fn render<'w>(
         _item: &P,
-        _view: ROQueryItem<'w, Self::ViewWorldQuery>,
-        pl_handle: ROQueryItem<'w, Self::ItemWorldQuery>,
+        _view: ROQueryItem<'w, Self::ViewQuery>,
+        pl_handle: Option<ROQueryItem<'w, Self::ItemQuery>>,
         polylines: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
-        if let Some(gpu_polyline) = polylines.into_inner().get(pl_handle) {
+        let Some(pl_h) = pl_handle else { return RenderCommandResult::Failure };
+        if let Some(gpu_polyline) = polylines.into_inner().get(pl_h) {
             pass.set_vertex_buffer(0, gpu_polyline.vertex_buffer.slice(..));
             let num_instances = gpu_polyline.vertex_count.max(1) - 1;
             pass.draw(0..6, 0..num_instances);


### PR DESCRIPTION
There' s a problem, maybe. In `material.rs`, line 349, the type `Opaque3d` now has an `asset_id` field. I set it to `AssetId::default()`, which seems wrong, as that would point to nothing. 

Despite this, all the examples ran correctly.

¯\_(ツ)_/¯