### PR TITLE
Implement round joins and caps

### DIFF
--- a/examples/joins.rs
+++ b/examples/joins.rs
@@ -1,0 +1,68 @@
+use std::f32::consts::TAU;
+
+use bevy::{
+    color::palettes::css::{BLUE, RED},
+    prelude::*,
+};
+use bevy_polyline::prelude::*;
+
+const NUM_STEPS: u16 = 8;
+const RADIUS: f32 = 1.0;
+const WIDTH: f32 = 60.0;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(PolylinePlugin)
+        .add_systems(Startup, setup)
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut polyline_materials: ResMut<Assets<PolylineMaterial>>,
+    mut polylines: ResMut<Assets<Polyline>>,
+) {
+    for (joins, offset, color) in [(false, -1.0, RED), (true, 1.0, BLUE)] {
+        let center = Vec3 {
+            x: 1.5 * offset,
+            y: 0.0,
+            z: 0.0,
+        };
+
+        let max = f32::from(NUM_STEPS);
+        let vertices = (0u16..NUM_STEPS + 1)
+            .map(|t| {
+                let angle = f32::from(t) / max * TAU;
+                Vec3 {
+                    x: angle.cos() * RADIUS,
+                    y: angle.sin() * RADIUS,
+                    z: 0.0,
+                } + center
+            })
+            .collect();
+
+        commands.spawn(PolylineBundle {
+            polyline: PolylineHandle(polylines.add(Polyline { vertices })),
+            material: PolylineMaterialHandle(polyline_materials.add(PolylineMaterial {
+                width: WIDTH,
+                color: color.into(),
+                perspective: false,
+                joins,
+                ..default()
+            })),
+            ..default()
+        });
+    }
+
+    // camera
+    commands.spawn((
+        Camera3d::default(),
+        Camera {
+            hdr: true,
+            ..default()
+        },
+        Msaa::Sample4,
+        Transform::from_xyz(0.0, 0.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
+}

--- a/src/material.rs
+++ b/src/material.rs
@@ -64,6 +64,9 @@ pub struct PolylineMaterial {
     ///
     /// Note that `depth_bias` **does not** interact with this in any way.
     pub perspective: bool,
+
+    // Whether to render round joins and caps, with a radius of half the line width.
+    pub joins: bool,
 }
 
 impl Default for PolylineMaterial {
@@ -73,6 +76,7 @@ impl Default for PolylineMaterial {
             color: Color::WHITE.to_linear(),
             depth_bias: 0.0,
             perspective: false,
+            joins: false,
         }
     }
 }
@@ -112,6 +116,7 @@ pub struct GpuPolylineMaterial {
     pub perspective: bool,
     pub bind_group: BindGroup,
     pub alpha_mode: AlphaMode,
+    pub joins: bool,
 }
 
 impl RenderAsset for GpuPolylineMaterial {
@@ -156,6 +161,7 @@ impl RenderAsset for GpuPolylineMaterial {
             perspective: polyline_material.perspective,
             alpha_mode,
             bind_group,
+            joins: polyline_material.joins,
         })
     }
 }
@@ -218,6 +224,15 @@ impl SpecializedRenderPipeline for PolylineMaterialPipeline {
                 .shader_defs
                 .push("POLYLINE_PERSPECTIVE".into());
         }
+
+        if key.contains(PolylinePipelineKey::JOINS) {
+            descriptor.vertex.shader_defs.push("JOINS".into());
+
+            if let Some(ref mut fragment) = descriptor.fragment {
+                fragment.shader_defs.push("JOINS".into());
+            }
+        }
+
         descriptor.layout = vec![
             self.polyline_pipeline.view_layout.clone(),
             self.polyline_pipeline.polyline_layout.clone(),
@@ -321,6 +336,9 @@ pub fn queue_material_polylines(
             }
             if material.perspective {
                 polyline_key |= PolylinePipelineKey::PERSPECTIVE
+            }
+            if material.joins {
+                polyline_key |= PolylinePipelineKey::JOINS
             }
             let pipeline_id =
                 pipelines.specialize(&pipeline_cache, &material_pipeline, polyline_key);

--- a/src/polyline.rs
+++ b/src/polyline.rs
@@ -8,7 +8,6 @@ use bevy::{
         },
     },
     prelude::*,
-    reflect::TypePath,
     render::{
         extract_component::{ComponentUniforms, DynamicUniformIndex, UniformComponentPlugin},
         render_asset::{PrepareAssetError, RenderAsset, RenderAssetPlugin, RenderAssets},
@@ -284,6 +283,7 @@ bitflags::bitflags! {
         const PERSPECTIVE = (1 << 0);
         const TRANSPARENT_MAIN_PASS = (1 << 1);
         const HDR = (1 << 2);
+        const JOINS = (1 << 3);
         const MSAA_RESERVED_BITS = Self::MSAA_MASK_BITS << Self::MSAA_SHIFT_BITS;
     }
 }


### PR DESCRIPTION
- Add `joins` property to `PolylineMaterial` struct (default: false)
- Add new example demonstrating joins

Fixes ForesightMiningSoftwareCorporation/bevy_polyline#1