### PR TITLE
Upgrade 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ authors = [
 
 [dependencies]
 bitflags = "2.3"
-bevy = { version = "0.16.1", default-features = false, features = [
+bevy = { version = "0.16", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_render",
     "bevy_asset",
@@ -29,7 +29,7 @@ bytemuck = "1.16.1"
 lazy_static = "1.4.0"
 rand = "0.9.1"
 ringbuffer = "0.15"
-bevy = { version = "0.16.1", default-features = false, features = [
+bevy = { version = "0.16", default-features = false, features = [
     "bevy_window",
     "bevy_winit",
     "bevy_pbr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ authors = [
 
 [dependencies]
 bitflags = "2.3"
-bevy = { version = "0.15", default-features = false, features = [
+bevy = { version = "0.16.1", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_render",
     "bevy_asset",
@@ -27,9 +27,9 @@ bytemuck = "1.16.1"
 
 [dev-dependencies]
 lazy_static = "1.4.0"
-rand = "0.8.4"
+rand = "0.9.1"
 ringbuffer = "0.15"
-bevy = { version = "0.15", default-features = false, features = [
+bevy = { version = "0.16.1", default-features = false, features = [
     "bevy_window",
     "bevy_winit",
     "bevy_pbr",

--- a/examples/depth_bias.rs
+++ b/examples/depth_bias.rs
@@ -41,18 +41,22 @@ fn rotate_plane(time: Res<Time>, mut animated: Query<(&mut Transform, &Rotating)
     }
 }
 
-fn move_camera(input: Res<ButtonInput<KeyCode>>, mut camera: Query<&mut Transform, With<Camera>>) {
-    if let Ok(mut camera_transform) = camera.get_single_mut() {
-        let trans = &mut camera_transform.translation;
-        let go_forward = input.any_pressed([KeyCode::ArrowUp, KeyCode::KeyI, KeyCode::KeyW]);
-        let go_backward = input.any_pressed([KeyCode::ArrowDown, KeyCode::KeyK, KeyCode::KeyS]);
-        if go_forward && trans.x > 10.0 {
-            trans.x -= 2.0;
-        } else if go_backward && trans.x < 500.0 {
-            trans.x += 2.0;
-        }
+fn move_camera(
+    input: Res<ButtonInput<KeyCode>>,
+    mut camera: Query<&mut Transform, With<Camera>>,
+) -> Result {
+    let mut camera_transform = camera.single_mut()?;
+    let trans = &mut camera_transform.translation;
+    let go_forward = input.any_pressed([KeyCode::ArrowUp, KeyCode::KeyI, KeyCode::KeyW]);
+    let go_backward = input.any_pressed([KeyCode::ArrowDown, KeyCode::KeyK, KeyCode::KeyS]);
+    if go_forward && trans.x > 10.0 {
+        trans.x -= 2.0;
+    } else if go_backward && trans.x < 500.0 {
+        trans.x += 2.0;
     }
+    Ok(())
 }
+
 fn setup(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,

--- a/examples/nbody.rs
+++ b/examples/nbody.rs
@@ -30,7 +30,10 @@ fn main() {
             Update,
             ((nbody_system, update_trails).chain(), rotator_system),
         )
-        .add_plugins(FrameTimeDiagnosticsPlugin)
+        .add_plugins(FrameTimeDiagnosticsPlugin {
+            smoothing_factor: 0.5,
+            max_history_length: 100,
+        })
         .add_plugins(LogDiagnosticsPlugin::default())
         .run();
 }
@@ -42,14 +45,14 @@ fn setup(
 ) {
     let mut rng = StdRng::seed_from_u64(0);
     for _index in 0..NUM_BODIES {
-        let r = rng.gen_range(2f32..800f32);
-        let theta = rng.gen_range(0f32..2.0 * PI);
+        let r = rng.random_range(2f32..800f32);
+        let theta = rng.random_range(0f32..2.0 * PI);
         let position = Vec3A::new(
             r * f32::cos(theta),
-            rng.gen_range(-500f32..500f32),
+            rng.random_range(-500f32..500f32),
             r * f32::sin(theta),
         );
-        let size = rng.gen_range(50f32..1000f32);
+        let size = rng.random_range(50f32..1000f32);
         commands.spawn((
             Body {
                 mass: size,
@@ -65,8 +68,12 @@ fn setup(
                 material: PolylineMaterialHandle(
                     polyline_materials.add(PolylineMaterial {
                         width: (size * 0.1).powf(1.8),
-                        color: Color::hsl(rng.gen_range(0.0..360.0), 1.0, rng.gen_range(1.2..3.0))
-                            .to_linear(),
+                        color: Color::hsl(
+                            rng.random_range(0.0..360.0),
+                            1.0,
+                            rng.random_range(1.2..3.0),
+                        )
+                        .to_linear(),
                         perspective: true,
                         ..Default::default()
                     }),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,10 @@
 #![allow(clippy::type_complexity)]
 #![allow(clippy::too_many_arguments)]
 
-use bevy::{asset::load_internal_asset, prelude::*};
+use bevy::{
+    asset::{load_internal_asset, weak_handle},
+    prelude::*,
+};
 use material::PolylineMaterialPlugin;
 use polyline::{PolylineBasePlugin, PolylineRenderPlugin};
 
@@ -15,7 +18,7 @@ pub mod prelude {
 }
 pub struct PolylinePlugin;
 
-pub const SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(12823766040132746065);
+pub const SHADER_HANDLE: Handle<Shader> = weak_handle!("00000000-0000-0000-b1f7-2b4530d47b51");
 
 impl Plugin for PolylinePlugin {
     fn build(&self, app: &mut bevy::prelude::App) {

--- a/src/material.rs
+++ b/src/material.rs
@@ -23,11 +23,13 @@ use bevy::{
         render_phase::*,
         render_resource::{binding_types::uniform_buffer, *},
         renderer::{RenderDevice, RenderQueue},
-        view::{ExtractedView, RenderVisibleEntities, RetainedViewEntity, ViewUniformOffset},
+        view::{
+            ExtractedView, RenderVisibleEntities, RetainedViewEntity, ViewUniformOffset,
+            VisibilityClass,
+        },
         Render, RenderApp, RenderSet,
     },
 };
-use std::fmt::Debug;
 
 #[derive(Debug, Clone, Default, Component, ExtractComponent)]
 pub struct PolylineMaterialHandle(pub Handle<PolylineMaterial>);
@@ -159,8 +161,6 @@ impl RenderAsset for GpuPolylineMaterial {
     }
 }
 
-pub type WithPolyline = With<PolylineHandle>;
-
 /// Adds the necessary ECS resources and render logic to enable rendering entities using ['PolylineMaterial']
 #[derive(Default)]
 pub struct PolylineMaterialPlugin;
@@ -170,10 +170,6 @@ impl Plugin for PolylineMaterialPlugin {
         app.init_asset::<PolylineMaterial>()
             .add_plugins(ExtractComponentPlugin::<PolylineMaterialHandle>::default())
             .add_plugins(RenderAssetPlugin::<GpuPolylineMaterial>::default());
-        // .add_systems(
-        //     PostUpdate,
-        //     check_visibility.in_set(VisibilitySystems::CheckVisibility),
-        // );
     }
 
     fn finish(&self, app: &mut App) {
@@ -310,9 +306,13 @@ pub fn queue_material_polylines(
         let inverse_view_matrix = view.world_from_view.compute_matrix().inverse();
         let inverse_view_row_2 = inverse_view_matrix.row(2);
 
+        println!("kaas");
+
         let mut polyline_key = PolylinePipelineKey::from_msaa_samples(msaa.samples());
         polyline_key |= PolylinePipelineKey::from_hdr(view.hdr);
-        for (visible_entity, visible_main_entity) in visible_entities.get::<WithPolyline>() {
+        for (visible_entity, visible_main_entity) in visible_entities.iter::<PolylineHandle>() {
+            println!("lalala");
+
             let Ok((material_handle, polyline_uniform)) = material_meshes.get(*visible_entity)
             else {
                 continue;

--- a/src/material.rs
+++ b/src/material.rs
@@ -306,12 +306,12 @@ pub fn queue_material_polylines(
         let inverse_view_matrix = view.world_from_view.compute_matrix().inverse();
         let inverse_view_row_2 = inverse_view_matrix.row(2);
 
-        println!("kaas");
+        println!("iter views");
 
         let mut polyline_key = PolylinePipelineKey::from_msaa_samples(msaa.samples());
         polyline_key |= PolylinePipelineKey::from_hdr(view.hdr);
         for (visible_entity, visible_main_entity) in visible_entities.iter::<PolylineHandle>() {
-            println!("lalala");
+            println!("iter visible entities");
 
             let Ok((material_handle, polyline_uniform)) = material_meshes.get(*visible_entity)
             else {

--- a/src/polyline.rs
+++ b/src/polyline.rs
@@ -79,6 +79,7 @@ impl RenderAsset for GpuPolyline {
 
     fn prepare_asset(
         polyline: Self::SourceAsset,
+        _id: AssetId<Self::SourceAsset>,
         render_device: &mut bevy::ecs::system::SystemParamItem<Self::Param>,
     ) -> Result<Self, PrepareAssetError<Self::SourceAsset>> {
         let vertex_buffer_data = bytemuck::cast_slice(polyline.vertices.as_slice());

--- a/src/polyline.rs
+++ b/src/polyline.rs
@@ -16,7 +16,7 @@ use bevy::{
         render_resource::{binding_types::uniform_buffer, *},
         renderer::RenderDevice,
         sync_world::{RenderEntity, SyncToRenderWorld},
-        view::{ViewUniform, ViewUniforms},
+        view::{add_visibility_class, ViewUniform, ViewUniforms},
         Extract, Render, RenderApp, RenderSet,
     },
 };
@@ -70,6 +70,7 @@ pub struct Polyline {
 
 #[derive(Debug, Clone, Default, Component)]
 #[require(SyncToRenderWorld)]
+#[component(on_add = add_visibility_class::<PolylineHandle>)]
 pub struct PolylineHandle(pub Handle<Polyline>);
 
 impl RenderAsset for GpuPolyline {


### PR DESCRIPTION
Hey guys! How are you? 

I'm doing the ridiculous thing of updating POLDERS to bevy 0.16, and I was using polylines.

I've tried my best to understand what's going on and make the appropriate updates.

Currently, i'm stuck on the changes regarding `RenderVisibleEntities` and `VisibilityClass`, the migration guide tells us to change:

```rust
visible_entities.get_mut<With<Mesh3d>>();
```
into
```rust
visible_entities.get_mut(TypeId::of::<Mesh3d>());
````
But this is not the right syntax. Moreover, while I'm using the appropriate new hooks, I can't seem to query the visible polylines. Can you guys see the issue?



