### PR TITLE
Update to bevy 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "bevy_polyline"
-version = "0.12.0"
+version = "0.13.0"
 description = "Polyline Rendering for Bevy"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/ForesightMiningSoftwareCorporation/bevy_polyline"
@@ -18,23 +18,24 @@ authors = [
 
 [dependencies]
 bitflags = "2.3"
-bevy = { version = "0.16", default-features = false, features = [
+bevy = { version = "0.17", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_render",
     "bevy_asset",
 ] }
+bevy_post_process = "0.17"
 bytemuck = "1.16.1"
 
 [dev-dependencies]
 lazy_static = "1.4.0"
 rand = "0.8.4"
 ringbuffer = "0.15"
-bevy = { version = "0.16", default-features = false, features = [
+bevy = { version = "0.17", default-features = false, features = [
     "bevy_window",
     "bevy_winit",
     "bevy_pbr",
     "x11",
     "tonemapping_luts",
     "ktx2",
-    "zstd",
+    "zstd_rust",
 ] }

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ We intend to track the `main` branch of Bevy. PRs supporting this are welcome!
 
 | bevy | bevy_polyline |
 | ---- | ------------- |
+| 0.17 | 0.13          |
 | 0.16 | 0.12          |
 | 0.15 | 0.11          |
 | 0.14 | 0.10          |

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,4 +1,4 @@
-use bevy::{color::palettes::css::RED, prelude::*};
+use bevy::{color::palettes::css::RED, prelude::*, render::view::Hdr};
 use bevy_polyline::prelude::*;
 
 fn main() {
@@ -30,10 +30,8 @@ fn setup(
     // camera
     commands.spawn((
         Camera3d::default(),
-        Camera {
-            hdr: true,
-            ..default()
-        },
+        Camera::default(),
+        Hdr,
         Msaa::Sample4,
         Transform::from_xyz(0.0, 0.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
     ));

--- a/examples/nbody.rs
+++ b/examples/nbody.rs
@@ -1,12 +1,14 @@
 use std::f32::consts::PI;
 
 use bevy::{
-    core_pipeline::{bloom::Bloom, tonemapping::Tonemapping},
+    core_pipeline::tonemapping::Tonemapping,
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     math::Vec3A,
     prelude::*,
+    render::view::Hdr,
 };
 use bevy_polyline::prelude::*;
+use bevy_post_process::bloom::Bloom;
 
 use lazy_static::*;
 use rand::{prelude::*, Rng};
@@ -79,10 +81,8 @@ fn setup(
     // camera
     commands.spawn((
         Camera3d::default(),
-        Camera {
-            hdr: true,
-            ..default()
-        },
+        Camera::default(),
+        Hdr,
         Msaa::Sample4,
         Tonemapping::TonyMcMapface,
         Bloom::default(),

--- a/examples/perspective.rs
+++ b/examples/perspective.rs
@@ -1,4 +1,4 @@
-use bevy::{color::palettes::css::RED, prelude::*};
+use bevy::{color::palettes::css::RED, prelude::*, render::view::Hdr};
 use bevy_polyline::prelude::*;
 
 fn main() {
@@ -33,10 +33,8 @@ fn setup(
         Camera3d::default(),
         Msaa::Sample4,
         Transform::from_xyz(0.0, 0.0, 2.0).looking_at(Vec3::ZERO, Vec3::Y),
-        Camera {
-            hdr: true,
-            ..default()
-        },
+        Camera::default(),
+        Hdr,
     ));
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::too_many_arguments)]
 
 use bevy::{
-    asset::{load_internal_asset, weak_handle},
+    asset::{load_internal_asset, uuid_handle},
     prelude::*,
 };
 use material::PolylineMaterialPlugin;
@@ -18,7 +18,7 @@ pub mod prelude {
 }
 pub struct PolylinePlugin;
 
-pub const SHADER_HANDLE: Handle<Shader> = weak_handle!("b180bfe9-10c8-48fe-b27a-dfa41436d7d0");
+pub const SHADER_HANDLE: Handle<Shader> = uuid_handle!("b180bfe9-10c8-48fe-b27a-dfa41436d7d0");
 
 impl Plugin for PolylinePlugin {
     fn build(&self, app: &mut bevy::prelude::App) {


### PR DESCRIPTION
Minimal changes. I opted to use ``zstd_rust`` because it was a dev dependency, so I'm assuming the priority is stability. ``bevy_post_processing`` added because one example included bloom, and ``bevy_post_processing`` wasn't cooperating as an added feature to bevy itself.