### PR TITLE
Update polyline to bevy 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "bevy_polyline"
-version = "0.13.0"
+version = "0.14.0"
 description = "Polyline Rendering for Bevy"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/ForesightMiningSoftwareCorporation/bevy_polyline"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,19 +18,19 @@ authors = [
 
 [dependencies]
 bitflags = "2.3"
-bevy = { version = "0.17", default-features = false, features = [
+bevy = { version = "0.18", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_render",
     "bevy_asset",
 ] }
-bevy_post_process = "0.17"
+bevy_post_process = "0.18"
 bytemuck = "1.16.1"
 
 [dev-dependencies]
 lazy_static = "1.4.0"
 rand = "0.8.4"
 ringbuffer = "0.15"
-bevy = { version = "0.17", default-features = false, features = [
+bevy = { version = "0.18", default-features = false, features = [
     "bevy_window",
     "bevy_winit",
     "bevy_pbr",

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ We intend to track the `main` branch of Bevy. PRs supporting this are welcome!
 
 | bevy | bevy_polyline |
 | ---- | ------------- |
+| 0.18 | 0.14          |
 | 0.17 | 0.13          |
 | 0.16 | 0.12          |
 | 0.15 | 0.11          |

--- a/src/material.rs
+++ b/src/material.rs
@@ -9,7 +9,7 @@ use bevy::{
         prepass::{OpaqueNoLightmap3dBatchSetKey, OpaqueNoLightmap3dBinKey},
     },
     ecs::{
-        component::Tick,
+        change_detection::Tick,
         query::ROQueryItem,
         system::{
             lifetimeless::{Read, SRes},
@@ -76,8 +76,8 @@ impl Default for PolylineMaterial {
 }
 
 impl PolylineMaterial {
-    pub fn bind_group_layout(render_device: &RenderDevice) -> BindGroupLayout {
-        render_device.create_bind_group_layout(
+    pub fn bind_group_layout_descriptor() -> BindGroupLayoutDescriptor {
+        BindGroupLayoutDescriptor::new(
             "polyline_material_layout",
             &BindGroupLayoutEntries::single(
                 ShaderStages::VERTEX,
@@ -116,6 +116,7 @@ impl RenderAsset for GpuPolylineMaterial {
     type SourceAsset = PolylineMaterial;
     type Param = (
         SRes<RenderDevice>,
+        SRes<PipelineCache>,
         SRes<RenderQueue>,
         SRes<PolylineMaterialPipeline>,
     );
@@ -123,7 +124,9 @@ impl RenderAsset for GpuPolylineMaterial {
     fn prepare_asset(
         polyline_material: Self::SourceAsset,
         _: AssetId<Self::SourceAsset>,
-        (device, queue, polyline_pipeline): &mut bevy::ecs::system::SystemParamItem<Self::Param>,
+        (device, cache, queue, polyline_pipeline): &mut bevy::ecs::system::SystemParamItem<
+            Self::Param,
+        >,
         _: Option<&Self>,
     ) -> Result<Self, PrepareAssetError<Self::SourceAsset>> {
         let value = PolylineMaterialUniform {
@@ -141,7 +144,7 @@ impl RenderAsset for GpuPolylineMaterial {
 
         let bind_group = device.create_bind_group(
             Some("polyline_material_bind_group"),
-            &polyline_pipeline.material_layout,
+            &cache.get_bind_group_layout(&polyline_pipeline.material_layout),
             &BindGroupEntries::single(buffer_binding),
         );
 
@@ -190,13 +193,12 @@ impl Plugin for PolylineMaterialPlugin {
 #[derive(Resource)]
 pub struct PolylineMaterialPipeline {
     pub polyline_pipeline: PolylinePipeline,
-    pub material_layout: BindGroupLayout,
+    pub material_layout: BindGroupLayoutDescriptor,
 }
 
 impl FromWorld for PolylineMaterialPipeline {
     fn from_world(world: &mut World) -> Self {
-        let render_device = world.get_resource::<RenderDevice>().unwrap();
-        let material_layout = PolylineMaterial::bind_group_layout(render_device);
+        let material_layout = PolylineMaterial::bind_group_layout_descriptor();
         let pipeline = world.get_resource::<PolylinePipeline>().unwrap();
         PolylineMaterialPipeline {
             polyline_pipeline: pipeline.to_owned(),


### PR DESCRIPTION
Minor changes needed for https://bevy.org/learn/migration-guides/0-17-to-0-18/#renderpipelinedescriptor-and-computepipelinedescriptor-now-hold-a-bindgrouplayoutdescriptor