### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ We intend to track the `main` branch of Bevy. PRs supporting this are welcome!
 
 | bevy | bevy_polyline |
 | ---- | ------------- |
+| 0.18 | 0.14          |
 | 0.17 | 0.13          |
 | 0.16 | 0.12          |
 | 0.15 | 0.11          |


### PR DESCRIPTION
There were missing entries for the bevy 0.18 version in the readme.